### PR TITLE
Prevent from never recovering from an error.

### DIFF
--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -495,8 +495,6 @@ sub logWrite
 ####################################################################################################################################
 # auditWrite
 ####################################################################################################################################
-my $oAuditCSV = new PgAudit::CSV({binary => 1, empty_is_undef => 1});
-
 sub auditWrite
 {
     my $strSessionId = shift;
@@ -506,6 +504,7 @@ sub auditWrite
 
     if ($strMessage =~ /^AUDIT\:\ /)
     {
+        my $oAuditCSV = new PgAudit::CSV({binary => 1, empty_is_undef => 1});
         $oAuditCSV->parse(substr($strMessage, 7));
         my @stryRow = $oAuditCSV->fields();
         my $lStatementId = $stryRow[AUDIT_FIELD_STATEMENT_ID];
@@ -717,7 +716,6 @@ while(!$bDone)
         sleep(5);
 
         # Reset everything and start again
-        undef($oAuditCSV);
         undef(%oDbHash);
         undef(%oSessionHash);
         undef(%oLogonHash);


### PR DESCRIPTION
Hi,

this is a fix for the behaviour of the Log Analyzer which I observed e.g. when starting the Log Analyzer in parallel with PostgreSQL like with

`/usr/lib/postgresql/9.5/bin/postgres  & bin/pgaudit_analyze /var/log/postgresql`

In case an error occurs (e.g. due to PostgreSQL server is still starting up), the variable oAuditCSV is reset and the Log Analyzer keeps emitting errors like

`Can't call method "parse" on an undefined value at pgaudit/analyze/bin/pgaudit_analyze line 510, <$hFile> line 34.`

With this patch applied, the Log Analyzer recovers from the error and starts collecting audit entries when the PostgreSQL server is ready (but I have to admit I did not run the regression tests).

Thanks!
Tom