### PR TITLE
Fixes for unable to open log file; autocommit off when loading audit.sql; redefining oAuditCSV when undefined

### DIFF
--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -631,7 +631,7 @@ my $strNextLogFile = nextLogFile($strLogPath);
 
 # Open log file
 open(my $hLog, '>', $strLogOutFile)
-    or confess "Unable to open pgaudit log file $strLogOutFile: $!";
+    or confess "Unable to open pgAudit Analyze log file $strLogOutFile: $!";
 
 # Daemonize the process
 daemonInit()
@@ -639,6 +639,12 @@ daemonInit()
 
 while(!$bDone)
 {
+    # If the audit CSV object is undefined (e.g. reset when if an error occurred) then redefine it
+    if (!defined($oAuditCSV))
+    {
+        $oAuditCSV = new PgAudit::CSV({binary => 1, empty_is_undef => 1});
+    }
+
     eval
     {
         if (!defined($strNextLogFile))

--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -631,7 +631,7 @@ my $strNextLogFile = nextLogFile($strLogPath);
 
 # Open log file
 open(my $hLog, '>', $strLogOutFile)
-    or confess "Unable to open pgAudit Analyze log file $strLogOutFile: $!";
+    or confess "unable to open pgAudit Analyze log file $strLogOutFile: $!";
 
 # Daemonize the process
 daemonInit()
@@ -639,7 +639,7 @@ daemonInit()
 
 while(!$bDone)
 {
-    # If the audit CSV object is undefined (e.g. reset when if an error occurred) then redefine it
+    # If the audit CSV object is undefined (e.g. reset if an error occurred) then redefine it
     if (!defined($oAuditCSV))
     {
         $oAuditCSV = new PgAudit::CSV({binary => 1, empty_is_undef => 1});

--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -631,7 +631,7 @@ my $strNextLogFile = nextLogFile($strLogPath);
 
 # Open log file
 open(my $hLog, '>', $strLogOutFile)
-    or confess "Unable to open log file: $!";
+    or confess "Unable to open pgaudit log file $strLogOutFile: $!";
 
 # Daemonize the process
 daemonInit()

--- a/sql/audit.sql
+++ b/sql/audit.sql
@@ -4,6 +4,9 @@
 -- Make sure that errors are detected and not automatically rolled back
 \set ON_ERROR_ROLLBACK off
 
+-- wrap in transaction block in the event AUTOCOMMIT is off
+BEGIN;
+
 -- Create pgaudit extension
 CREATE EXTENSION IF NOT EXISTS pgaudit;
 
@@ -254,3 +257,5 @@ select session.session_id,
        inner join pgaudit.audit_statement
             on audit_statement.session_id = audit_substatement_detail.session_id
            and audit_statement.statement_id = audit_substatement_detail.statement_id;
+
+COMMIT;

--- a/test/test.pl
+++ b/test/test.pl
@@ -722,6 +722,18 @@ $strSql =
 
 pgQueryTest($strSql);
 
+# Verify that correct error is thrown when unable to open log file
+#-------------------------------------------------------------------------------
+&log("\nTEST: Verify 'unable to open pgAudit Analyze log file'\n");
+eval
+{
+    capture("${strBasePath}/bin/pgaudit_analyze --log-file=/var/log/pgaudit_analyze.log ${strTestPath}/pg_log");
+};
+if ($@)
+{
+    &log("TEST PASSED - Verify 'unable to open pgAudit Analyze log file'");
+}
+
 &log(undef, undef, true);
 
 # Cleanup


### PR DESCRIPTION
Fixes:
1) pgaudit_analyze - unable to open log file #5
2) Add begin;commit; to audit.sql #3
3) Prevent from never recovering from an error. #1