### PR TITLE
fix bug when updating pgaudit.audit_statement.pgaudit.audit_statement

### DIFF
--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -280,6 +280,7 @@ sub databaseGet
         "                on audit_substatement_detail.session_id = log_event.session_id\n" .
         "               and audit_substatement_detail.session_line_num = log_event.session_line_num\n" .
         "               and audit_substatement_detail.statement_id = audit_statement_update.statement_id\n" .
+        "               and audit_substatement_detail.session_id = audit_statement_update.session_id\n" .
         "           inner join pgaudit.audit_statement\n" .
         "                on audit_statement.session_id = audit_substatement_detail.session_id\n" .
         "               and audit_statement.statement_id = audit_substatement_detail.statement_id\n" .

--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -30,7 +30,7 @@ pgaudit_analyze [options] <pg-log-path>
  Configuration Options:
    --daemon             run as a daemon (consider running under upstart or systemctl)
    --port               port that PostgreSQL is running on (defaults to 5432)
-   --socket-path        socket directory used by PostgreSQL (default to system default directory)
+   --socket-path        PostgreSQL host or socket directory (default to system default directory)
    --log-file           location of the log file for pgaudit_analyze (defaults to /var/log/pgaudit_analyze.log)
    --user               specify postgres user instead of using pgaudit_analyze invoker
 


### PR DESCRIPTION
The exists sub query can eval to true for all rows
this can incorrectly mark an error
OR cause a crash when violating  foreign key constraint "auditstatement_sessionid_sessionlinenum_fk"
if the line num from the error does not exist in log_event for another session_id

example log:
```
DETAIL:  parameters: $1 = '7', $2 = '5f7ca847.34dce', $3 = '11/18685'
ERROR:  insert or update on table "audit_statement" violates foreign key constraint "auditstatement_sessionid_sessionlinenum_fk"
DETAIL:  Key (session_id, error_session_line_num)=(5f76a5c2.3d15c, 7) is not present in table "log_event".
STATEMENT:  commit
```
Notice the ```statement_id```s are different between the parameter passed in and the actual foreign key error.
The is b/c the exists subquery evaluated to True for all rows.
If the other session_id had a line number that matched the param it would have incorrectly set state='error'  