### PR TITLE
Close STDERR when running as a daemon.

### DIFF
--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -602,6 +602,8 @@ sub daemonInit
         or confess "Couldn't close standard input: $!";
     open STDOUT, '>', $strLogOutFile
         or confess "Couldn't close standard output: $!";
+    open STDERR, '<', '/dev/null'
+        or confess "Couldn't close standard error: $!";
 
     # create new process
     defined($pid = fork)


### PR DESCRIPTION
When testing on the CentOS8 Stream OS and trying to run the pgaudit_analyze binary as a daemon over an ssh connection, the entire ssh connection would hang and never return.  After a lot of investigation, we wer able to determine that this was happening when using openssh 8.0p1-9.el8 and also 8.0p1-8.el8.  However, when you downgrade openssh to 8.0p1-7.el8, launching the daemon works as it has in the past.  After digging through the openssh commits we found this:

On May 2, 2021, CentOS 8 Stream packagers introduced a change to its openssh libraries, which you can see here: https://git.centos.org/rpms/openssh/c/1c3003998fcc4d40fe9e4544bca70dbc03324e65?branch=c8s 

After a lot more digging and testing, the issue was related to the fact that STDERR was never closed so in the newer openssh versions it would not release the connection and would hang.  After adding the code below we are again able to run the pgaudit_analyze daemon over an ssh connection like before.