### PR TITLE
when using pam authentication all logon failures marked as success

### DIFF
--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -108,6 +108,11 @@ use constant
 
 use constant
 {
+    PAM_ERROR => 'pam_authenticate failed:'
+};
+
+use constant
+{
     true    => 1,
     false   => 0
 };
@@ -318,6 +323,7 @@ sub sessionGet
     my $strConnectionFrom = shift;
     my $strCommandTag = shift;
     my $strErrorSeverity = shift;
+    my $strMessage = shift;
 
     # Set connection from to a default if not defined yet
     if (!defined($strApplicationName))
@@ -336,7 +342,8 @@ sub sessionGet
 
     # Set state to ERROR on authentication failure
     if (defined($strCommandTag) && lc($strCommandTag) eq COMMAND_TAG_AUTHENTICATION &&
-        defined($strErrorSeverity) && lc($strErrorSeverity) eq ERROR_SEVERITY_FATAL)
+        ( (defined($strErrorSeverity) && lc($strErrorSeverity) eq ERROR_SEVERITY_FATAL) ||
+          (defined($strMessage) && index($strMessage, PAM_ERROR) == 0 ) ))
     {
         $strState = STATE_ERROR;
     }
@@ -710,7 +717,7 @@ while(!$bDone)
             {
                 sessionGet($strSessionId, $lSessionLineNum, $$stryRow[LOG_FIELD_PROCESS_ID], $$stryRow[LOG_FIELD_SESSION_START_TIME],
                            $strUserName, $strDatabaseName, $$stryRow[LOG_FIELD_APPLICATION_NAME], $$stryRow[LOG_FIELD_CONNECTION_FROM],
-                           $$stryRow[LOG_FIELD_COMMAND_TAG], $$stryRow[LOG_FIELD_ERROR_SEVERITY]);
+                           $$stryRow[LOG_FIELD_COMMAND_TAG], $$stryRow[LOG_FIELD_ERROR_SEVERITY], $$stryRow[LOG_FIELD_MESSAGE]);
 
                 logWrite($strSessionId, $strDatabaseName, $$stryRow[LOG_FIELD_LOG_TIME], $lSessionLineNum,
                          defined($$stryRow[LOG_FIELD_COMMAND_TAG]) ? lc($$stryRow[LOG_FIELD_COMMAND_TAG]) : undef,

--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -106,10 +106,15 @@ use constant
     STATE_ERROR => 'error'
 };
 
-use constant
-{
-    PAM_ERROR => 'pam_authenticate failed:'
-};
+####################################################################################################################################
+# Authentication errors that appear as type "LOG" before the type "FATAL" msg is recorded
+####################################################################################################################################
+my @AUTH_ERRORS = (
+    'pam_authenticate failed:',
+    'error from underlying PAM layer:',
+    'could not connect to Ident server at address'
+);
+
 
 use constant
 {
@@ -343,7 +348,7 @@ sub sessionGet
     # Set state to ERROR on authentication failure
     if (defined($strCommandTag) && lc($strCommandTag) eq COMMAND_TAG_AUTHENTICATION &&
         ( (defined($strErrorSeverity) && lc($strErrorSeverity) eq ERROR_SEVERITY_FATAL) ||
-          (defined($strMessage) && index($strMessage, PAM_ERROR) == 0 ) ))
+          (defined($strMessage) && grep {$strMessage =~ /^$_/} @AUTH_ERRORS )))
     {
         $strState = STATE_ERROR;
     }

--- a/test/README.md
+++ b/test/README.md
@@ -6,5 +6,5 @@ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f test/Dockerfil
 ```
 Then run the test. The path for the PostgreSQL version to be tested must be supplied:
 ```
-docker run --rm -v $(pwd):/pgaudit-analyze pgaudit-analyze-test /pgaudit-analyze/test/test.pl --pgsql-bin=/usr/lib/postgresql/13/bin
+docker run -v $(pwd):/pgaudit-analyze pgaudit-analyze-test /pgaudit-analyze/test/test.pl --pgsql-bin=/usr/lib/postgresql/13/bin
 ```


### PR DESCRIPTION
The issue is when using PAM auth a log msg of level LOG created before the FATAL msg
Pass in the msg and check it to catch this case.

Example logs from csv:

```
2021-07-22 14:49:47.420 EDT,,,13208,"127.0.0.1:34254",60f9bdcb.3398,1,"",2021-07-22 14:49:47 EDT,,0,LOG,00000,"connection received: host=127.0.0.1 port=34254",,,,,,,,,""
2021-07-22 14:49:48.938 EDT,"XXXXX","pgaudit",13208,"127.0.0.1:34254",60f9bdcb.3398,2,"authentication",2021-07-22 14:49:47 EDT,3/843974,0,LOG,00000,"pam_authenticate failed: User not known to the underlying authentication module",,,,,,,,,""
2021-07-22 14:49:48.938 EDT,"XXXXX","pgaudit",13208,"127.0.0.1:34254",60f9bdcb.3398,3,"authentication",2021-07-22 14:49:47 EDT,3/843974,0,FATAL,28000,"PAM authentication failed for user ""XXXXX""","Connection matched pg_hba.conf line 90: ""host    all             all             127.0.0.1/32            pam""",,,,,,,,""
```