### PR TITLE
Add seek needed to read a growing file on newer Perl versions.

### DIFF
--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -695,6 +695,11 @@ while(!$bDone)
             $oLogCSV = new PgAudit::CSV({binary => 1, empty_is_undef => 1});
         }
 
+        # As of Perl 5.36 they fixed an issue where you could continue reading a file that is being modified after hitting EOF
+        # https://groups.google.com/g/linux.debian.bugs.dist/c/ZaxLI8YufO8
+        # Therefore we need to seek to the current location to continue reading if the log has been added to
+        seek $hFile, 0, 1;
+
         # Parse all rows in the file into CSV
         while (my $stryRow = $oLogCSV->getline($hFile))
         {

--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -695,10 +695,11 @@ while(!$bDone)
             $oLogCSV = new PgAudit::CSV({binary => 1, empty_is_undef => 1});
         }
 
-        # As of Perl 5.36 they fixed an issue where you could continue reading a file that is being modified after hitting EOF
-        # https://groups.google.com/g/linux.debian.bugs.dist/c/ZaxLI8YufO8
-        # Therefore we need to seek to the current location to continue reading if the log has been added to
-        seek $hFile, 0, 1;
+        # Perl 5.36 fixed an issue where you could continue reading a file that is being modified after hitting EOF, see:
+        # https://groups.google.com/g/linux.debian.bugs.dist/c/ZaxLI8YufO8. Therefore we must seek to the current location to
+        # continue reading if the log is growing.
+        seek($hFile, 0, 1)
+            or confess "unable to seek to current position in ${strLogPath}/${strLogFile}";
 
         # Parse all rows in the file into CSV
         while (my $stryRow = $oLogCSV->getline($hFile))

--- a/bin/pgaudit_analyze
+++ b/bin/pgaudit_analyze
@@ -695,9 +695,9 @@ while(!$bDone)
             $oLogCSV = new PgAudit::CSV({binary => 1, empty_is_undef => 1});
         }
 
-        # Perl 5.36 fixed an issue where you could continue reading a file that is being modified after hitting EOF, see:
+        # Perl 5.36 fixed an issue where you could continue reading a file that was being appended to after hitting EOF, see:
         # https://groups.google.com/g/linux.debian.bugs.dist/c/ZaxLI8YufO8. Therefore we must seek to the current location to
-        # continue reading if the log is growing.
+        # continue reading if the log is being appended to.
         seek($hFile, 0, 1)
             or confess "unable to seek to current position in ${strLogPath}/${strLogFile}";
 


### PR DESCRIPTION
   The issue of interest:
https://groups.google.com/g/linux.debian.bugs.dist/c/ZaxLI8YufO8

   As of Perl 5.36, it appears that they have fixed the broken EOF handling and pgaudit_analyze will not continue to read the log after it parses it the first time.  This means that it is unable to get any new log entries that are added to a file after it opens it the first time.  To fix this, the PR includes a change to reset the file handler which clears the EOF flag.

   This specific issue was found because on Debian 12 (Bookworm) the default Perl version is now 5.36.0-7, which during our testing we found that the daemon was no longer updating.  After debugging and thinking that the daemon was dying, we realized that if we started the daemon again it would update the analyze DB to the current state of the log files, but not get any new updates.  After troubleshooting further, we found that it was related to the above bug and this small change appears to fix the issue.  

   We have tested various fixes and this one appears to be the least impactful on CPU utilization, but still resolves the issue in question.